### PR TITLE
Remove foreign key constraint

### DIFF
--- a/db/migrate/20151111222648_remove_foreign_key.rb
+++ b/db/migrate/20151111222648_remove_foreign_key.rb
@@ -1,0 +1,9 @@
+class RemoveForeignKey < ActiveRecord::Migration
+  def up
+    remove_foreign_key :redirections, column: :next_id
+  end
+
+  def down
+    add_foreign_key :redirections, :redirections, column: :next_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110191852) do
+ActiveRecord::Schema.define(version: 20151111222648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,5 +44,4 @@ ActiveRecord::Schema.define(version: 20151110191852) do
   add_index "redirections", ["slug"], name: "index_redirections_on_slug", unique: true, using: :btree
   add_index "redirections", ["url"], name: "index_redirections_on_url", unique: true, using: :btree
 
-  add_foreign_key "redirections", "redirections", column: "next_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,14 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+unless Redirection.exists?(slug: "gabe")
+  gabe = Redirection.create!(
+    slug: "gabe",
+    url: "http://gabebw.com",
+    next_id: -1, # fake data
+  )
+
+  edward = Redirection.new(
+    slug: "edward",
+    url: "http://edwardloveall.com",
+  )
+
+  Ring.new(edward).link
+end

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe RedirectionsController do
   describe "GET :next" do
     it "redirects to the next site" do
-      gabe = create(:redirection, :gabe)
-      edward = create(:redirection, :edward, next: gabe)
+      gabe = create(:redirection)
+      edward = create(:redirection, next: gabe)
       gabe.update(next: edward)
 
       get :next, slug: gabe.slug
@@ -15,8 +15,8 @@ RSpec.describe RedirectionsController do
 
   describe "GET :previous" do
     it "redirects to the previous site" do
-      gabe = create(:redirection, :gabe)
-      edward = create(:redirection, :edward, next: gabe)
+      gabe = create(:redirection)
+      edward = create(:redirection, next: gabe)
       gabe.update(next: edward)
 
       get :previous, slug: edward.slug

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,13 +1,13 @@
 FactoryGirl.define do
   factory :redirection do
-    trait :gabe do
-      slug "gabe"
-      url "http://gabebw.com"
-    end
+    sequence(:slug) { |n| "slug#{n}" }
+    sequence(:url) { |n| "http://example#{n}.com" }
+    next_id -1
 
-    trait :edward do
-      slug "edward"
-      url "http://edwardloveall.com"
+    after(:create) do |redirection|
+      if redirection.next_id == 0
+        Ring.new(redirection).link
+      end
     end
   end
 end

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -12,14 +12,19 @@ RSpec.describe Redirection do
   describe "validations" do
     it { should validate_presence_of :slug }
     it { should validate_presence_of :url }
-    it { should validate_uniqueness_of :next_id }
-    it { should validate_uniqueness_of :slug }
+
+    context "uniqueness" do
+      before { create(:redirection) }
+
+      it { should validate_uniqueness_of :next_id }
+      it { should validate_uniqueness_of :slug }
+    end
   end
 
   describe "#next_url" do
     it "returns the url of the next referenced redirection" do
-      gabe = create(:redirection, :gabe)
-      edward = create(:redirection, :edward, next: gabe)
+      gabe = create(:redirection)
+      edward = create(:redirection, next: gabe)
       gabe.update(next: edward)
 
       expect(gabe.next_url).to eq(edward.url)
@@ -28,8 +33,8 @@ RSpec.describe Redirection do
 
   describe "#previous_url" do
     it "returns the url of the previous referenced redirection" do
-      gabe = create(:redirection, :gabe)
-      edward = create(:redirection, :edward, next: gabe)
+      gabe = create(:redirection)
+      edward = create(:redirection, next: gabe)
       gabe.update(next: edward)
 
       expect(gabe.previous_url).to eq(edward.url)

--- a/spec/models/ring_spec.rb
+++ b/spec/models/ring_spec.rb
@@ -3,29 +3,15 @@ require "rails_helper"
 RSpec.describe Ring do
   describe "#link" do
     it "adds a new redirection while preserving the ring" do
-      redirection = Redirection.create!(
-        url: "http://example.com/1",
-        slug: "one",
-        next_id: 0,
-      )
-      other_redirection = Redirection.create!(
-        url: "http://example.com/2",
-        slug: "two",
-        next: redirection,
-      )
-      redirection.update!(next_id: other_redirection.id)
-      new_redirection = Redirection.new(
-        url: "http://example.com/3",
-        slug: "three",
-      )
+      new_redirection = build(:redirection)
 
       ring = Ring.new(new_redirection)
       ring.link
 
-      [redirection, other_redirection].each(&:reload)
-      expect(redirection.next).to eq other_redirection
-      expect(other_redirection.next).to eq new_redirection
-      expect(new_redirection.next).to eq redirection
+      redirections = Redirection.order(created_at: :asc)
+      expect(redirections[0].next).to eq redirections[1]
+      expect(redirections[1].next).to eq new_redirection
+      expect(new_redirection.next).to eq redirections[0]
     end
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,6 +1,8 @@
 RSpec.configure do |config|
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:deletion)
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+    Rails.application.load_seed
   end
 
   config.before(:each) do


### PR DESCRIPTION
The foreign key constraint on the `next_id` column meant that we can't insert the first record, because any ID we put on next_id won't be a valid foreign key (since there's nothing in the table).

This migration removes that foreign key constraint so that we can insert the first few records and kickstart the ring.

All specs are passing.