### PR TITLE
Easily add another link to the ring

### DIFF
--- a/app/models/ring.rb
+++ b/app/models/ring.rb
@@ -1,0 +1,19 @@
+class Ring
+  def initialize(redirection_to_link)
+    @oldest_redirection = Redirection.order(created_at: :desc).last
+    @newest_redirection = Redirection.order(created_at: :desc).first
+    @redirection_to_link = redirection_to_link
+  end
+
+  def link
+    Redirection.transaction do
+      redirection_to_link.update!(next_id: 0)
+      newest_redirection.update!(next: redirection_to_link)
+      redirection_to_link.update!(next: oldest_redirection)
+    end
+  end
+
+  private
+
+  attr_reader :oldest_redirection, :newest_redirection, :redirection_to_link
+end

--- a/spec/models/ring_spec.rb
+++ b/spec/models/ring_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Ring do
+  describe "#link" do
+    it "adds a new redirection while preserving the ring" do
+      redirection = Redirection.create!(
+        url: "http://example.com/1",
+        slug: "one",
+        next_id: 0,
+      )
+      other_redirection = Redirection.create!(
+        url: "http://example.com/2",
+        slug: "two",
+        next: redirection,
+      )
+      redirection.update!(next_id: other_redirection.id)
+      new_redirection = Redirection.new(
+        url: "http://example.com/3",
+        slug: "three",
+      )
+
+      ring = Ring.new(new_redirection)
+      ring.link
+
+      [redirection, other_redirection].each(&:reload)
+      expect(redirection.next).to eq other_redirection
+      expect(other_redirection.next).to eq new_redirection
+      expect(new_redirection.next).to eq redirection
+    end
+  end
+end


### PR DESCRIPTION
The `Ring` class takes care of breaking links, adding another redirection, and re-forming links to take into account the new entry.

It runs in a transaction so that if part of `Ring#link` fails, we're not left with junk data.

This should help with #5.