### PR TITLE
Always break the ring at the first element

### DIFF
--- a/app/models/ring.rb
+++ b/app/models/ring.rb
@@ -1,19 +1,18 @@
 class Ring
   def initialize(redirection_to_link)
-    @oldest_redirection = Redirection.order(created_at: :desc).last
-    @newest_redirection = Redirection.order(created_at: :desc).first
     @redirection_to_link = redirection_to_link
+    @from_redirection = Redirection.first
+    @to_redirection = from_redirection.next
   end
 
   def link
     Redirection.transaction do
-      redirection_to_link.update!(next_id: 0)
-      newest_redirection.update!(next: redirection_to_link)
-      redirection_to_link.update!(next: oldest_redirection)
+      from_redirection.update!(next: redirection_to_link)
+      redirection_to_link.update!(next: to_redirection)
     end
   end
 
   private
 
-  attr_reader :oldest_redirection, :newest_redirection, :redirection_to_link
+  attr_reader :from_redirection, :to_redirection, :redirection_to_link
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,5 +10,6 @@ unless Redirection.exists?(slug: "gabe")
     url: "http://edwardloveall.com",
   )
 
-  Ring.new(edward).link
+  edward.update!(next: gabe)
+  gabe.update!(next: edward)
 end

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -3,25 +3,23 @@ require "rails_helper"
 RSpec.describe RedirectionsController do
   describe "GET :next" do
     it "redirects to the next site" do
-      gabe = create(:redirection)
-      edward = create(:redirection, next: gabe)
-      gabe.update(next: edward)
+      gabe = Redirection.find_by!(slug: "gabe")
+      next_redirection = gabe.next
 
       get :next, slug: gabe.slug
 
-      expect(response).to redirect_to(edward.url)
+      expect(response).to redirect_to(next_redirection.url)
     end
   end
 
   describe "GET :previous" do
     it "redirects to the previous site" do
-      gabe = create(:redirection)
-      edward = create(:redirection, next: gabe)
-      gabe.update(next: edward)
+      gabe = Redirection.find_by!(slug: "gabe")
+      previous = Redirection.find_by!(next: gabe)
 
-      get :previous, slug: edward.slug
+      get :previous, slug: gabe.slug
 
-      expect(response).to redirect_to(gabe.url)
+      expect(response).to redirect_to(previous.url)
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     next_id -1
 
     after(:create) do |redirection|
-      if redirection.next_id == 0
+      if redirection.next_id == -1
         Ring.new(redirection).link
       end
     end

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -23,21 +23,22 @@ RSpec.describe Redirection do
 
   describe "#next_url" do
     it "returns the url of the next referenced redirection" do
-      gabe = create(:redirection)
-      edward = create(:redirection, next: gabe)
-      gabe.update(next: edward)
+      first = Redirection.first
+      redirection = build(:redirection)
+      Ring.new(redirection).link
 
-      expect(gabe.next_url).to eq(edward.url)
+      first.reload
+      expect(first.next_url).to eq(redirection.url)
     end
   end
 
   describe "#previous_url" do
     it "returns the url of the previous referenced redirection" do
-      gabe = create(:redirection)
-      edward = create(:redirection, next: gabe)
-      gabe.update(next: edward)
+      first = Redirection.first
+      redirection = build(:redirection)
+      Ring.new(redirection).link
 
-      expect(gabe.previous_url).to eq(edward.url)
+      expect(first.previous_url).to eq("http://edwardloveall.com")
     end
   end
 end

--- a/spec/models/ring_spec.rb
+++ b/spec/models/ring_spec.rb
@@ -4,14 +4,15 @@ RSpec.describe Ring do
   describe "#link" do
     it "adds a new redirection while preserving the ring" do
       new_redirection = build(:redirection)
+      gabe = Redirection.find_by!(slug: "gabe")
+      edward = Redirection.find_by!(slug: "edward")
 
       ring = Ring.new(new_redirection)
       ring.link
 
-      redirections = Redirection.order(created_at: :asc)
-      expect(redirections[0].next).to eq redirections[1]
-      expect(redirections[1].next).to eq new_redirection
-      expect(new_redirection.next).to eq redirections[0]
+      expect(gabe.reload.next).to eq new_redirection
+      expect(new_redirection.next).to eq edward
+      expect(edward.reload.next).to eq gabe
     end
   end
 end


### PR DESCRIPTION
Previously we were doing some, uh, interesting stuff around newest/oldest Redirections, which assumed that the newest redirection links to the oldest one.  That's not necessarily true.

Now we:

* Grab the first Redirection (`@from_redirection`)
* Grab the Redirection that that Redirection points to (`@to_redirection`)
* Break the link between them
* Insert a new redirection between them

This ensures that we're breaking a link that definitely exists, instead of breaking a link that we assume (based on creation time) exists.

This commit also refactors the tests to use the existing gabe/edward Redirections that are created via DB seeds.