### PR TITLE
Auto-create redirections

### DIFF
--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -1,13 +1,42 @@
 class RedirectionsController < ApplicationController
   def next
-    redirection = Redirection.find_by(slug: params[:slug])
+    redirection = find_or_create_redirection
 
     redirect_to redirection.next_url
   end
 
   def previous
-    redirection = Redirection.find_by(slug: params[:slug])
+    redirection = find_or_create_redirection
 
     redirect_to redirection.previous_url
+  end
+
+  private
+
+  def find_or_create_redirection
+    redirection = Redirection.find_by(slug: params[:slug])
+
+    redirection.presence || new_redirection
+  end
+
+  def new_redirection
+    redirection = Redirection.new(slug: params[:slug])
+
+    if referrer.present?
+      redirection.url = referrer_hostname
+      Ring.new(redirection).link
+      redirection
+    else
+      Redirection.first
+    end
+  end
+
+  def referrer_hostname
+    referrer_uri = URI.parse(referrer)
+    "#{referrer_uri.scheme}://#{referrer_uri.hostname}"
+  end
+
+  def referrer
+    request.env["HTTP_REFERER"]
   end
 end

--- a/app/models/ring.rb
+++ b/app/models/ring.rb
@@ -1,4 +1,6 @@
 class Ring
+  FAKE_ID = -1
+
   def initialize(redirection_to_link)
     @redirection_to_link = redirection_to_link
     @from_redirection = Redirection.first
@@ -7,6 +9,7 @@ class Ring
 
   def link
     Redirection.transaction do
+      redirection_to_link.update!(next_id: FAKE_ID)
       from_redirection.update!(next: redirection_to_link)
       redirection_to_link.update!(next: to_redirection)
     end

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -12,6 +12,58 @@ RSpec.describe RedirectionsController do
     end
   end
 
+  [:next, :previous].each do |action|
+    describe "GET #{action}" do
+      it "creates a Redirection if it doesn't exist" do
+        new_slug = "new"
+        url = "http://example.com"
+        first_redirection = Redirection.first
+        old_next = first_redirection.next
+
+        request.env["HTTP_REFERER"] = url
+        get action, slug: new_slug
+
+        new_redirection = Redirection.find_by!(slug: new_slug)
+        first_redirection.reload
+        expect(first_redirection.next.slug).to eq new_slug
+        expect(new_redirection.url).to eq url
+        expect(new_redirection.next).to eq old_next
+      end
+
+      it "uses the referrer's hostname, including subdomain" do
+        new_slug = "new"
+        hostname = "http://cool.example.com"
+
+        request.env["HTTP_REFERER"] = "#{hostname}/something/else"
+        get action, slug: new_slug
+
+        expect(Redirection.find_by!(slug: new_slug).url).to eq hostname
+      end
+
+      context "when there is no referrer" do
+        it "does not create a Redirection" do
+          new_slug = "new"
+
+          get action, slug: new_slug
+
+          expect(Redirection.exists?(slug: new_slug)).to be false
+        end
+
+        it "redirects to the first redirection's next/previous URL" do
+          new_slug = "new"
+
+          get action, slug: new_slug
+
+          if action == :next
+            expect(response).to redirect_to Redirection.first.next_url
+          else
+            expect(response).to redirect_to Redirection.first.previous_url
+          end
+        end
+      end
+    end
+  end
+
   describe "GET :previous" do
     it "redirects to the previous site" do
       gabe = Redirection.find_by!(slug: "gabe")


### PR DESCRIPTION
When we receive a request for `/new-slug/next` or `/new-slug/previous`, we:

* check if there's an entry for `new-slug`
* if there isn't, we add it to the ring
* redirect to the next/previous URL for `new-slug`