### PR TITLE
Extract a RedirectionCreation service

### DIFF
--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -14,26 +14,9 @@ class RedirectionsController < ApplicationController
   private
 
   def find_or_create_redirection
-    redirection = Redirection.find_by(slug: params[:slug])
-
-    redirection.presence || new_redirection
-  end
-
-  def new_redirection
-    redirection = Redirection.new(slug: params[:slug])
-
-    if referrer.present?
-      redirection.url = referrer_hostname
-      Ring.new(redirection).link
-      redirection
-    else
+    Redirection.find_by(slug: params[:slug]) ||
+      RedirectionCreation.perform(referrer, params[:slug]) ||
       Redirection.first
-    end
-  end
-
-  def referrer_hostname
-    referrer_uri = URI.parse(referrer)
-    "#{referrer_uri.scheme}://#{referrer_uri.hostname}"
   end
 
   def referrer

--- a/app/services/redirection_creation.rb
+++ b/app/services/redirection_creation.rb
@@ -1,0 +1,29 @@
+class RedirectionCreation
+  def self.perform(referrer, slug)
+    new(referrer, slug).perform
+  end
+
+  def initialize(referrer, slug)
+    @referrer = referrer
+    @slug = slug
+  end
+
+  def perform
+    redirection = Redirection.new(slug: slug)
+
+    if referrer.present?
+      redirection.url = referrer_hostname
+      Ring.new(redirection).link
+      redirection
+    end
+  end
+
+  private
+
+  attr_reader :referrer, :slug
+
+  def referrer_hostname
+    referrer_uri = URI.parse(referrer)
+    "#{referrer_uri.scheme}://#{referrer_uri.hostname}"
+  end
+end

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -23,32 +23,12 @@ RSpec.describe RedirectionsController do
         request.env["HTTP_REFERER"] = url
         get action, slug: new_slug
 
-        new_redirection = Redirection.find_by!(slug: new_slug)
-        first_redirection.reload
-        expect(first_redirection.next.slug).to eq new_slug
-        expect(new_redirection.url).to eq url
-        expect(new_redirection.next).to eq old_next
-      end
-
-      it "uses the referrer's hostname, including subdomain" do
-        new_slug = "new"
-        hostname = "http://cool.example.com"
-
-        request.env["HTTP_REFERER"] = "#{hostname}/something/else"
-        get action, slug: new_slug
-
-        expect(Redirection.find_by!(slug: new_slug).url).to eq hostname
+        new_redirection = Redirection.last
+        expect(new_redirection.slug).to eq new_slug
+        expect(first_redirection.reload.next).to eq new_redirection
       end
 
       context "when there is no referrer" do
-        it "does not create a Redirection" do
-          new_slug = "new"
-
-          get action, slug: new_slug
-
-          expect(Redirection.exists?(slug: new_slug)).to be false
-        end
-
         it "redirects to the first redirection's next/previous URL" do
           new_slug = "new"
 

--- a/spec/services/redirection_creation_spec.rb
+++ b/spec/services/redirection_creation_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe RedirectionCreation do
+  context "when the referrer is present" do
+    it "creates a redirection with the referrer hostname" do
+      referrer_hostname = "https://cool.example.com"
+      slug = "cool-slug"
+
+      RedirectionCreation.perform(
+        "#{referrer_hostname}/something",
+        slug,
+      )
+
+      redirection = Redirection.find_by!(slug: slug)
+      expect(redirection.url).to eq referrer_hostname
+    end
+
+    it "links the new redirection into the ring" do
+      first_redirection = Redirection.first
+      old_next = first_redirection.next
+
+      redirection = RedirectionCreation.perform(
+        "http://example.com",
+        "slug",
+      )
+
+      expect(redirection.previous).to eq first_redirection
+      expect(redirection.next).to eq old_next
+    end
+  end
+
+  context "when the referrer is blank" do
+    it "always returns nil" do
+      result = RedirectionCreation.perform("", "slug")
+
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
RedirectionCreation handles creating (or not creating!) a new Redirection based on a slug and referrer. It also links the new redirection into the ring.

Since we handle edge cases (like a blank referrer) at the RedirectionCreation unit test level, the controller specs can now be correspondingly simpler.