### PR TITLE
Add webring links to the landing page

### DIFF
--- a/app/assets/stylesheets/_landing-page.scss
+++ b/app/assets/stylesheets/_landing-page.scss
@@ -14,10 +14,19 @@
     &:last-child {
       margin-bottom: 2rem;
     }
+
+    a {
+      color: white;
+    }
   }
 
   h3 {
     font-size: $base-font-size * 2;
+  }
+
+  .explanation {
+    @include shift(2);
+    @include span-columns(8);
   }
 
   iframe {

--- a/app/assets/stylesheets/base/_grid-settings.scss
+++ b/app/assets/stylesheets/base/_grid-settings.scss
@@ -4,7 +4,7 @@
 // $column: 90px;
 // $gutter: 30px;
 // $grid-columns: 12;
-$max-width: 800px;
+$max-width: 1200px;
 
 // Neat Breakpoints
 $medium-screen: 600px;

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,37 +1,48 @@
 <header>
-  <% 6.times do %>
+  <% 2.times do %>
+    <h2><%= title %></h2>
+  <% end %>
+
+  <h2>
+    <a href="http://hotlinewebring.club/hotlinewebring/previous">&larr;</a>
+    <%= title %>
+    <a href="http://hotlinewebring.club/hotlinewebring/next">&rarr;</a>
+  </h2>
+  <% 2.times do %>
     <h2><%= title %></h2>
   <% end %>
 </header>
 
-<p>Wanna join the coolest webring? Here's how.</p>
+<section class="explanation">
+  <p>Wanna join the coolest webring? Here's how.</p>
 
-<ol>
-  <li>Choose a unique slug. If your website were gabebw.com, you might use
-    <strong>gabebw</strong>. Using something based on your website is a good
-    idea because it's likely to be unique.</li>
-  <li>Add links on your website: <strong>http://hotlinewebring.club/YOUR-SLUG/next</strong> and <strong>http://hotlinewebring.club/YOUR-SLUG/previous</strong></li>
-  <li>You're done! When someone clicks on one of your links, you'll be automatically added to the webring.</li>
-</ol>
+  <ol>
+    <li>Choose a unique slug. If your website were gabebw.com, you might use
+      <strong>gabebw</strong>. Using something based on your website is a good
+      idea because it's likely to be unique.</li>
+    <li>Add links on your website: <strong>http://hotlinewebring.club/YOUR-SLUG/next</strong> and <strong>http://hotlinewebring.club/YOUR-SLUG/previous</strong></li>
+    <li>You're done! When someone clicks on one of your links, you'll be automatically added to the webring.</li>
+  </ol>
 
-<h3>FAQ</h3>
+  <h3>FAQ</h3>
 
-<p>
-  Q: Can I control who I link to?</br>
-  A: No, sorry, it's all automatic. But on the bright side it's easy to sign up!
-</p>
+  <p>
+    Q: Can I control who I link to?</br>
+    A: No, sorry, it's all automatic. But on the bright side it's easy to sign up!
+  </p>
 
-<p>
-  Q: Is my slug taken?</br>
-  A: You tell me:
+  <p>
+    Q: Is my slug taken?</br>
+    A: You tell me:
 
-  <table class="redirections">
-    <tr>
-      <th>Slug</th>
-      <th>URL</th>
-    </tr>
-    <%= render @redirections %>
-  </table>
-</p>
+    <table class="redirections">
+      <tr>
+        <th>Slug</th>
+        <th>URL</th>
+      </tr>
+      <%= render @redirections %>
+    </table>
+  </p>
 
-<iframe width="800" height="450" src="https://www.youtube-nocookie.com/embed/uxpDa-c-4Mc?rel=0" frameborder="0" allowfullscreen></iframe>
+  <iframe width="800" height="450" src="https://www.youtube-nocookie.com/embed/uxpDa-c-4Mc?rel=0" frameborder="0" allowfullscreen></iframe>
+</section>


### PR DESCRIPTION
People should be able to use the webring right away.

There's some SCSS weirdness with `shift` and `max-width` to make the body text about as narrow as the "HOTLINE WEBRING" without the arrows, while making `$max-width` large enough to let the layout to accommodate the arrows. I welcome feedback.