### PR TITLE
Fix regression on homepage

### DIFF
--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -25,12 +25,12 @@
   Q: Is my slug taken?</br>
   A: You tell me:
 
-  <table>
+  <table class="redirections">
     <tr>
       <th>Slug</th>
       <th>URL</th>
     </tr>
-    <%= render redirections %>
+    <%= render @redirections %>
   </table>
 </p>
 

--- a/spec/features/user_visits_homepage_spec.rb
+++ b/spec/features/user_visits_homepage_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature "User visits homepage" do
   scenario "sees list of redirections" do
     visit root_path
 
-    expect(page.html).to have_css("table.redirections")
-
     within("table.redirections") do
       expect(page).to have_content("gabebw")
       expect(page).to have_content("http://gabebw.com")

--- a/spec/features/user_visits_homepage_spec.rb
+++ b/spec/features/user_visits_homepage_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "User visits homepage" do
+  scenario "sees list of redirections" do
+    visit root_path
+
+    expect(page.html).to have_css("table.redirections")
+
+    within("table.redirections") do
+      expect(page).to have_content("gabebw")
+      expect(page).to have_content("http://gabebw.com")
+      expect(page).to have_content("edward")
+      expect(page).to have_content("http://edwardloveall.com")
+    end
+  end
+end


### PR DESCRIPTION
In a previous (now squashed) commit, I had a helper method for
`redirections` on the homepage to avoid an ivar. However, I changed
back to an ivar in the `HomesController` but not in the view. The app
crashed on the homepage.

This is now tested for.