### PR TITLE
Link to the sites on the homepage

### DIFF
--- a/app/views/redirections/_redirection.html.erb
+++ b/app/views/redirections/_redirection.html.erb
@@ -1,4 +1,4 @@
 <tr>
   <td><%= redirection.slug %></td>
-  <td><%= link_to(redirection.url) %></td>
+  <td><%= link_to(redirection.url, redirection.url) %></td>
 </tr>

--- a/spec/features/user_visits_homepage_spec.rb
+++ b/spec/features/user_visits_homepage_spec.rb
@@ -6,9 +6,12 @@ RSpec.feature "User visits homepage" do
 
     within("table.redirections") do
       expect(page).to have_content("gabebw")
-      expect(page).to have_content("http://gabebw.com")
       expect(page).to have_content("edward")
-      expect(page).to have_content("http://edwardloveall.com")
+
+      %w(http://gabebw.com http://edwardloveall.com).each do |url|
+        expect(page).to have_content(url)
+        expect(page).to have_css("a[href='#{url}']")
+      end
     end
   end
 end


### PR DESCRIPTION
Previously we weren't providing a URL to `link_to` so it was linking to the hotlinewebring.club site.