### PR TITLE
Ignore people arriving from localhost

### DIFF
--- a/app/assets/stylesheets/_landing-page.scss
+++ b/app/assets/stylesheets/_landing-page.scss
@@ -11,11 +11,6 @@
     }
   }
 
-  .explanation {
-    @include shift(2);
-    @include span-columns(8);
-  }
-
   iframe {
     margin-top: 2em;
   }

--- a/app/assets/stylesheets/_landing-page.scss
+++ b/app/assets/stylesheets/_landing-page.scss
@@ -1,15 +1,6 @@
 .homes-show {
-  h2, h3 {
-    color: white;
-    font-style: italic;
-    text-align: center;
-  }
-
   h2 {
-    font-size: $base-font-size * 5;
-    line-height: 0.9;
     margin-bottom: 0;
-    text-transform: uppercase;
 
     &:last-child {
       margin-bottom: 2rem;
@@ -18,10 +9,6 @@
     a {
       color: white;
     }
-  }
-
-  h3 {
-    font-size: $base-font-size * 2;
   }
 
   .explanation {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,8 @@ body {
 main {
   @include outer-container;
 }
+
+.text {
+  @include shift(2);
+  @include span-columns(8);
+}

--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -6,16 +6,29 @@ body {
   line-height: $base-line-height;
 }
 
+h2 {
+  font-size: $base-font-size * 5;
+  line-height: 0.9;
+}
+
+h3 {
+  font-size: $base-font-size * 2;
+}
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
+  color: white;
   font-family: $heading-font-family;
-  font-size: $base-font-size;
+  font-style: italic;
+  font-style: italic;
   line-height: $heading-line-height;
   margin: 0 0 $small-spacing;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 p {

--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -1,4 +1,6 @@
 class RedirectionsController < ApplicationController
+  before_action :ensure_referrer_is_not_localhost
+
   def next
     redirection = find_or_create_redirection
 
@@ -21,5 +23,11 @@ class RedirectionsController < ApplicationController
 
   def referrer
     request.env["HTTP_REFERER"]
+  end
+
+  def ensure_referrer_is_not_localhost
+    if referrer.present? && URI.parse(referrer).host == "localhost"
+      redirect_to page_path("localhost")
+    end
   end
 end

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 </header>
 
-<section class="explanation">
+<section class="text">
   <p>Wanna join the coolest webring? Here's how.</p>
 
   <ol>

--- a/app/views/pages/localhost.html.erb
+++ b/app/views/pages/localhost.html.erb
@@ -1,0 +1,22 @@
+<header>
+  <h2>Hey there!</h2>
+</header>
+
+<section class="text">
+  <p>Looks like you're testing out your links on your local site.</p>
+  <p>
+    That's totally fine, but this site uses the referrer to insert you into the webring.
+    That means that clicking your hotline webring links would add
+    <code>http://localhost</code> as your entry in the webring, which is
+    definitely not what you want.
+  </p>
+  <p>
+    To keep localhost out of the webring, we ignore requests from localhost and
+    don't add them to the webring.  But don't worry! When you click on your real
+    site it'll work!
+  </p>
+  <p>
+    P.S. Remember, don't click on your links on staging, either, or your staging
+    website will be added to the webring.
+  </p>
+</section>

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe RedirectionsController do
         expect(first_redirection.reload.next).to eq new_redirection
       end
 
+      it "ignores requests from localhost" do
+        request.env["HTTP_REFERER"] = "http://localhost:3000"
+
+        get action, slug: "whatever"
+
+        expect(response).to redirect_to page_path(:localhost)
+      end
+
       context "when there is no referrer" do
         it "redirects to the first redirection's next/previous URL" do
           new_slug = "new"


### PR DESCRIPTION
Please check out #22 first.

When people click links on their site running on `http://localhost:3000`, we were adding `http://localhost` to the webring.

Now we don't add localhost requests to the webring, and we provide a helpful explanation of what's going on.