### PR TITLE
Mobile-ify the layout

### DIFF
--- a/app/assets/stylesheets/_mobile.scss
+++ b/app/assets/stylesheets/_mobile.scss
@@ -1,0 +1,27 @@
+@include media($large-screen-down) {
+  h2 {
+    font-size: 3.5em;
+  }
+
+  .homes-show {
+    iframe {
+      display: none;
+    }
+  }
+}
+
+@include media($medium-screen-down) {
+  h2 {
+    font-size: 1.5em;
+  }
+
+  .homes-show {
+    .explanation {
+      @include span-columns(3);
+    }
+
+    iframe {
+      display: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,11 +7,4 @@
 @import "base/base";
 @import "refills/flashes";
 @import "landing-page";
-
-body {
-  background-color: $base-background-color;
-}
-
-main {
-  @include outer-container;
-}
+@import "mobile";

--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -13,3 +13,11 @@
 @import "lists";
 @import "tables";
 @import "typography";
+
+body {
+  background-color: $base-background-color;
+}
+
+main {
+  @include outer-container;
+}

--- a/app/assets/stylesheets/base/_grid-settings.scss
+++ b/app/assets/stylesheets/base/_grid-settings.scss
@@ -10,5 +10,5 @@ $max-width: 1200px;
 $medium-screen: 600px;
 $large-screen: 900px;
 
-$medium-screen-up: new-breakpoint(min-width $medium-screen 4);
-$large-screen-up: new-breakpoint(min-width $large-screen 8);
+$medium-screen-down: new-breakpoint(max-width $medium-screen 4);
+$large-screen-down: new-breakpoint(max-width $large-screen 8);


### PR DESCRIPTION
On mobile screens:

* Hide the giant video
* Use a smaller header text so each "HOTLINE WEBRING" header is on its own line instead of breaking over multiple lines

I tested it with Safari's (extremely handy) Responsive Design Mode, and the site looks good on everything from an iPhone 4S to an iPad Pro.