### PR TITLE
Use has_link matcher to test homepage

### DIFF
--- a/spec/features/user_visits_homepage_spec.rb
+++ b/spec/features/user_visits_homepage_spec.rb
@@ -5,12 +5,8 @@ RSpec.feature "User visits homepage" do
     visit root_path
 
     within("table.redirections") do
-      expect(page).to have_content("gabebw")
-      expect(page).to have_content("edward")
-
-      %w(http://gabebw.com http://edwardloveall.com).each do |url|
-        expect(page).to have_content(url)
-        expect(page).to have_css("a[href='#{url}']")
+      Redirection.all.each do |redirection|
+        expect(page).to have_link(redirection.slug, href: redirection.url)
       end
     end
   end


### PR DESCRIPTION
I always forget, but capybara has a `has_link` or `have_link` matcher
that can be used to test if a link is on a page:
http://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_link%3F-instance_method

This cleans up a test for us nicely.