### PR TITLE
Add RSpec formatter for Circle CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :test do
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
+  gem "rspec_junit_formatter"
   gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,9 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
     safe_yaml (1.0.4)
     sass (3.4.19)
     sass-rails (5.0.4)
@@ -300,6 +303,7 @@ DEPENDENCIES
   recipient_interceptor
   refills
   rspec-rails (~> 3.3.0)
+  rspec_junit_formatter
   sass-rails (~> 5.0)
   shoulda-matchers
   simple_form

--- a/circle.yml
+++ b/circle.yml
@@ -6,4 +6,5 @@ database:
     - bin/setup
 test:
   override:
-    - bundle exec rake
+    - RAILS_ENV=test bundle exec rspec -r rspec_junit_formatter --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+    - bundle exec rake bundler:audit


### PR DESCRIPTION
With this formatter, Circle should pretty-print our failures. We need a custom spec command because otherwise Circle only runs RSpec, while `bundle exec rake` runs `rake bundle:audit` as well.

https://circleci.com/docs/test-metadata#automatic-test-metadata-collection

I also changed the specs so we can see how failures look now. I'll remove the failures before merging.