### PR TITLE
Ignore a wider variety of local requests

### DIFF
--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -26,7 +26,7 @@ class RedirectionsController < ApplicationController
   end
 
   def ensure_referrer_is_not_localhost
-    if referrer.present? && URI.parse(referrer).host == "localhost"
+    if HostValidator.new(referrer).invalid?
       redirect_to page_path("localhost")
     end
   end

--- a/app/models/host_validator.rb
+++ b/app/models/host_validator.rb
@@ -1,0 +1,32 @@
+class HostValidator
+  INVALID_HOSTS = %w(127.0.0.1 localhost)
+  INVALID_TLDS = %w(.dev)
+
+  def initialize(url)
+    @url = url
+  end
+
+  def invalid?
+    if url.present?
+      invalid_host? || invalid_tld?
+    else
+      false
+    end
+  end
+
+  private
+
+  attr_reader :url
+
+  def invalid_host?
+    INVALID_HOSTS.include?(host)
+  end
+
+  def invalid_tld?
+    INVALID_TLDS.include?(File.extname(host))
+  end
+
+  def host
+    URI.parse(url).host
+  end
+end

--- a/app/views/pages/localhost.html.erb
+++ b/app/views/pages/localhost.html.erb
@@ -7,13 +7,13 @@
   <p>
     That's totally fine, but this site uses the referrer to insert you into the webring.
     That means that clicking your hotline webring links would add
-    <code>http://localhost</code> as your entry in the webring, which is
-    definitely not what you want.
+    something like <code>http://localhost</code> as your entry in the webring,
+    which is definitely not what you want.
   </p>
   <p>
-    To keep localhost out of the webring, we ignore requests from localhost and
-    don't add them to the webring.  But don't worry! When you click on your real
-    site it'll work!
+    To keep local hosts out of the webring, we ignore requests from localhost
+    (and a few others, like <code>127.0.0.1</code>) and don't add them to the
+    webring. But don't worry! When you click on your real site it'll work!
   </p>
   <p>
     P.S. Remember, don't click on your links on staging, either, or your staging

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe RedirectionsController do
         expect(first_redirection.reload.next).to eq new_redirection
       end
 
-      it "ignores requests from localhost" do
-        request.env["HTTP_REFERER"] = "http://localhost:3000"
+      it "ignores requests from http://example.dev" do
+        request.env["HTTP_REFERER"] = "http://example.dev"
 
         get action, slug: "whatever"
 

--- a/spec/models/host_validator_spec.rb
+++ b/spec/models/host_validator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe HostValidator do
+  describe "#invalid?" do
+    %w(
+      http://localhost:3000
+      http://example.dev
+      http://127.0.0.1:3000
+    ).each do |ignored|
+      it "returns true for #{ignored}" do
+        host_validator = HostValidator.new(ignored)
+
+        expect(host_validator.invalid?).to be true
+      end
+    end
+
+    it "returns false when there is no referrer" do
+      host_validator = HostValidator.new(nil)
+
+      expect(host_validator.invalid?).to be false
+    end
+
+    it "returns false for non-local domains" do
+      host_validator = HostValidator.new("http://gabebw.com")
+
+      expect(host_validator.invalid?).to be false
+    end
+  end
+end


### PR DESCRIPTION
Previously we were only checking for referrers from `localhost`. Now we check for:

* `localhost` (like `http://localhost:3000`)
* `127.0.0.1` (like `http://127.0.0.1:3000`)
* `*.dev` (like `http://example.dev`)

Introduce a `HostValidator` model to cover the new logic.