### PR TITLE
Force SSL in production (and staging)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.force_ssl = true
   config.middleware.use Rack::Deflater
   config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
Now that Cloudflare gives us SSL, we should force people to use it instead of plain ol' HTTP.