### PR TITLE
Recommend secure webring links

### DIFF
--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -4,9 +4,9 @@
   <% end %>
 
   <h2>
-    <a href="http://hotlinewebring.club/hotlinewebring/previous">&larr;</a>
+    <a href="https://hotlinewebring.club/hotlinewebring/previous">&larr;</a>
     <%= title %>
-    <a href="http://hotlinewebring.club/hotlinewebring/next">&rarr;</a>
+    <a href="https://hotlinewebring.club/hotlinewebring/next">&rarr;</a>
   </h2>
   <% 2.times do %>
     <h2><%= title %></h2>
@@ -20,7 +20,7 @@
     <li>Choose a unique slug. If your website were gabebw.com, you might use
       <strong>gabebw</strong>. Using something based on your website is a good
       idea because it's likely to be unique.</li>
-    <li>Add links on your website: <strong>http://hotlinewebring.club/YOUR-SLUG/next</strong> and <strong>http://hotlinewebring.club/YOUR-SLUG/previous</strong></li>
+    <li>Add links on your website: <strong>https://hotlinewebring.club/YOUR-SLUG/next</strong> and <strong>https://hotlinewebring.club/YOUR-SLUG/previous</strong></li>
     <li>You're done! When someone clicks on one of your links, you'll be automatically added to the webring.</li>
   </ol>
 


### PR DESCRIPTION
* When an HTTPS site links to the HTTP version of Hotline Webring, it won't send a Referer header
* Hotline Webring relies on the Referer header to know which site to add to the ring
* Linking to the HTTPS version of Hotline Webring ensures that we always get a Referer header, whether the linking site is using HTTPS or not