### PR TITLE
Use created_at in atom feed entries

### DIFF
--- a/app/views/feeds/show.atom.builder
+++ b/app/views/feeds/show.atom.builder
@@ -9,7 +9,7 @@ atom_feed do |feed|
     feed.tag!(:entry) do |entry|
       entry.id redirection.tag_uri
       entry.title "#{redirection.slug} joined #{title}"
-      entry.updated redirection.updated_at.iso8601
+      entry.updated redirection.created_at.iso8601
       entry.content redirection.url
       entry.link redirection.url
       entry.author do |author|

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -36,6 +36,19 @@ RSpec.describe "Feed requests" do
       expect(first_entry["id"]).to eq(id)
       expect(first_entry["updated"]).to eq(updated)
     end
+
+    it "uses created_at instead of updated_at for <updated> value" do
+      created_at = 1.day.from_now
+      create(
+        :redirection,
+        created_at: created_at,
+        updated_at: created_at + 1.day
+      )
+
+      get feed_path
+
+      expect(first_entry["updated"]).to eq(created_at.iso8601)
+    end
   end
 
   def xml


### PR DESCRIPTION
When a new Redirection is added to the webring, the first Redirection in the ring points to it. This changes that first Redirection's `updated_at` value.

In the atom feed, we were using `updated_at` to say when that entry was updated. While that's semantic, it would cause the first Redirection to continue to pop up in atom feeds because it looked like there was new information. No longer!

We now use `created_at` in that field, because for the purposes of the feed, we only want to see each Redirection when it's added, not "updated".