### PR TITLE
Update rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,14 +114,22 @@ Style/StringLiteralsInInterpolation:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/TrailingComma:
-  Description: Checks for trailing comma in parameter lists and literals.
+Style/TrailingCommaInArguments:
+  Description: Checks for trailing comma in parameter lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
-  Enabled: false
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStyles:
-  - comma
-  - no_comma
+    - comma
+    - consistent_comma
+    - no_comma
+Style/TrailingCommaInLiteral:
+  Description: Checks for trailing comma in literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+  EnforcedStyleForMultiline: consistent_comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.


### PR DESCRIPTION
`Style/TrailingComma` has now been split up into `Style/TrailingCommaInArguments` and `Style/TrailingCommaInLiteral`