### PR TITLE
Only repeat the site's name once in the header

### DIFF
--- a/app/assets/stylesheets/_landing-page.scss
+++ b/app/assets/stylesheets/_landing-page.scss
@@ -1,4 +1,14 @@
 .homes-show {
+  header {
+    a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
   h2 {
     margin-bottom: 0;
 

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -1,16 +1,9 @@
 <header>
-  <% 2.times do %>
-    <h2><%= title %></h2>
-  <% end %>
-
   <h2>
     <a href="https://hotlinewebring.club/hotlinewebring/previous">&larr;</a>
     <%= title %>
     <a href="https://hotlinewebring.club/hotlinewebring/next">&rarr;</a>
   </h2>
-  <% 2.times do %>
-    <h2><%= title %></h2>
-  <% end %>
 </header>
 
 <section class="text">


### PR DESCRIPTION
Remove the underlines on the arrow links.