### PR TITLE
Show the slug in the Atom feed

### DIFF
--- a/app/views/feeds/show.atom.builder
+++ b/app/views/feeds/show.atom.builder
@@ -9,6 +9,7 @@ atom_feed do |feed|
     feed.tag!(:entry) do |entry|
       entry.id redirection.tag_uri
       entry.title "#{redirection.slug} joined #{title}"
+      entry.slug redirection.slug
       entry.updated redirection.created_at.iso8601
       entry.content redirection.url
       entry.link redirection.url

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Feed requests" do
       get feed_path
 
       expect(first_entry["title"]).to eq(title)
+      expect(first_entry["slug"]).to eq(redirection.slug)
       expect(first_entry["content"]).to eq(content)
       expect(first_entry["link"]).to eq(redirection.url)
       expect(first_entry["author"]["name"]).to eq("Gabe and Edward")


### PR DESCRIPTION
This will make it easier to parse for anyone who writes, say, a best-selling iOS app.