### PR TITLE
Store the path for referrers with home directories

### DIFF
--- a/app/services/redirection_creation.rb
+++ b/app/services/redirection_creation.rb
@@ -12,7 +12,7 @@ class RedirectionCreation
     redirection = Redirection.new(slug: slug)
 
     if referrer.present?
-      redirection.url = referrer_hostname
+      redirection.url = normalized_referrer
       Ring.new(redirection).link
       redirection
     end
@@ -22,8 +22,19 @@ class RedirectionCreation
 
   attr_reader :referrer, :slug
 
+  def normalized_referrer
+    if referrer_uri.path.start_with?("/~")
+      referrer_hostname + File.dirname(referrer_uri.path)
+    else
+      referrer_hostname
+    end
+  end
+
   def referrer_hostname
-    referrer_uri = URI.parse(referrer)
     "#{referrer_uri.scheme}://#{referrer_uri.hostname}"
+  end
+
+  def referrer_uri
+    @_referrer_uri ||= URI.parse(referrer)
   end
 end

--- a/spec/services/redirection_creation_spec.rb
+++ b/spec/services/redirection_creation_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe RedirectionCreation do
       expect(redirection.previous).to eq first_redirection
       expect(redirection.next).to eq old_next
     end
+
+    context "when the referrer is like http://tilde.club/~ford/something.html"do
+      it "creates a redirection that includes the ~ford" do
+        referrer = "http://tilde.club/~ford/something.html"
+        slug = "cool-slug"
+
+        RedirectionCreation.perform(referrer, slug)
+
+        redirection = Redirection.find_by!(slug: slug)
+        expect(redirection.url).to eq "http://tilde.club/~ford"
+      end
+    end
   end
 
   context "when the referrer is blank" do


### PR DESCRIPTION
Until now, the webring always normalized referrers to the hostname, with no path (like `tilde.club`). Here's a case where that breaks down.

A classic method of user management for shared servers like http://tilde.club/ is to store each user's content under a top-level path like `/~gabe`.

Gabe would be at tilde.club/~gabe, Edward would be at tilde.club/~edward, and so on. One person curates `/~gabe`, another person curates `/~edward`, and a third person curates the tilde.club homepage itself.

In the case of shared servers, when someone adds webring links to a page on (e.g.) `tilde.club/~gabe/webring.html`, the webring stores `tilde.club`. We should instead respect each user's individuality and store that site's URL as `tilde.club/~gabe`.

Fixes #44.