### PR TITLE
Add a test for visiting a High Voltage page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashdiff (0.2.2)
-    high_voltage (2.4.0)
+    high_voltage (3.0.0)
     i18n (0.7.0)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)

--- a/spec/features/user_visits_localhost_page_spec.rb
+++ b/spec/features/user_visits_localhost_page_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.feature "User visits localhost page" do
+  scenario "sees localhost text" do
+    visit page_path("localhost")
+
+    expect(page).to have_text "testing out your links on your local site"
+  end
+end


### PR DESCRIPTION
On production, starting the server immediately fails with this error:

    undefined method `hide_action' for HighVoltage::PagesController:Class

This is because `hide_action` was removed from controllers in Rails 5.

This error does _not_ occur in development or test because those environments have `config.eager_load` set to `false`, so the `HighVoltage::PagesController` code is never loaded, and thus doesn't fail.

The test added in this commit exercises the `HighVoltage::PagesController` code, and fails without upgrading high_voltage.

To fix this issue, upgrade to high_voltage 3.0.0, which supports Rails 5: https://github.com/thoughtbot/high_voltage/blob/master/NEWS.md