### PR TITLE
Add a method to remove a site from the webring

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ is [purposefully excluded from the project's `Gemfile`][exclude].
 [foreman]: https://github.com/ddollar/foreman
 [exclude]: https://github.com/ddollar/foreman/pull/437#issuecomment-41110407
 
+## Removing a site from the webring
+
+Use `Redirection#unlink`:
+
+    irb> redirection = Redirection.find_by(slug: "whatever")
+    irb> redirection.unlink
+
+This will destroy the `Redirection` and re-link its ring neighbors, sealing the
+breach.
+
 ## Guidelines
 
 Use the following guides for getting things done, programming well, and

--- a/app/models/redirection.rb
+++ b/app/models/redirection.rb
@@ -26,4 +26,14 @@ class Redirection < ActiveRecord::Base
 
     "tag:#{UNCHANGING_HOSTNAME},#{date}:#{url}"
   end
+
+  def unlink
+    previous_redirection = previous
+    next_redirection = self.next
+
+    self.class.transaction do
+      destroy!
+      previous_redirection.update!(next: next_redirection)
+    end
+  end
 end

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -83,4 +83,27 @@ RSpec.describe Redirection do
       expect(redirection.tag_uri).to eq(id)
     end
   end
+
+  describe "#unlink" do
+    it "destroys the redirection" do
+      redirection = create(:redirection)
+
+      redirection.unlink
+
+      expect(Redirection.exists?(id: redirection.id)).to be_falsey
+    end
+
+    it "links the redirection's previous to its next" do
+      gabe = Redirection.find_by!(slug: "gabe")
+      edward = Redirection.find_by!(slug: "edward")
+      redirection = create(:redirection)
+
+      redirection.unlink
+
+      edward.reload
+      gabe.reload
+      expect(edward.next).to eq gabe
+      expect(gabe.next).to eq edward
+    end
+  end
 end


### PR DESCRIPTION
I know, I know: who would want such a thing?!

The `unlink` method runs in a transaction so that removing a Redirection and re-linking its neighbors is an atomic operation. In other words, we can't remove a Redirection, run into an error, and then leave a hole in the ring.