### PR TITLE
Add link_audit rake task

### DIFF
--- a/lib/tasks/link-audit.rake
+++ b/lib/tasks/link-audit.rake
@@ -1,0 +1,27 @@
+desc "Determine if all websites have links"
+task link_audit: :environment do
+  def green(text)
+    puts "\e[32m#{text}\e[0m"
+  end
+
+  def red(text)
+    puts "\e[31m#{text}\e[0m"
+  end
+
+  Redirection.find_each do |redirection|
+    url = URI(redirection.url)
+    html = Net::HTTP.get(url)
+    next_link = "hotlinewebring.club/#{redirection.slug}/next"
+    prev_link = "hotlinewebring.club/#{redirection.slug}/previous"
+
+    missing_links = []
+    missing_links << "next" if !html.include?(next_link)
+    missing_links << "prev" if !html.include?(prev_link)
+
+    if missing_links.empty?
+      green("#{redirection.url} is all good")
+    else
+      red("#{redirection.url} is missing #{missing_links.join(' and ')}")
+    end
+  end
+end


### PR DESCRIPTION
This taks should help us to maintenance on the webring's members. It
checks each redirection for proper next and previous links. It downloads
the page and scans the raw html for the proper urls. It doesn't check
for actual links because some sites (looking at you @jnutting) don't use
normal `<a href="...">` links.

This also found other issues while I was testing it like sites that have
migrated to https because the html only returned the redirection (and
therefore didn't include the links).