### PR TITLE
Remove staging environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :test do
   gem "webmock"
 end
 
-group :staging, :production do
+group :production do
   gem "rack-timeout"
   gem "rails_stdout_logging"
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,5 +18,3 @@ production: &deploy
   pool: <%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
   url:  <%= ENV.fetch("DATABASE_URL", "") %>
-
-staging: *deploy

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-  config.force_ssl = true
+  config.force_ssl = ENV.fetch("USE_SSL", false)
   config.middleware.use Rack::Deflater
   config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
   config.assets.js_compressor = :uglifier

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,6 +1,0 @@
-require_relative "production"
-
-Rails.application.configure do
-  config.force_ssl = false
-  config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
-end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -28,7 +28,3 @@ test:
 production:
   <<: *default_settings
   monitor_mode: true
-staging:
-  <<: *default_settings
-  app_name: "hotline-webring (Staging)"
-  monitor_mode: true

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,8 +7,5 @@ development:
 test:
   <<: *default
 
-staging:
-  <<: *default
-
 production:
   <<: *default


### PR DESCRIPTION
`RAILS_ENV` is set to `production` on the staging and production environments (as recommended by Heroku).

Since both staging and production environments load `production.rb`, we introduce a `USE_SSL` environment variable that will only be enabled in the production environment. Staging does not have SSL set up.

I already set `USE_SSL` on production:

    $ heroku config:get USE_SSL -a hotline-webring-production
    true