### PR TITLE
Remove capybara-webkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara-webkit"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,9 +57,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.11.1)
-      capybara (>= 2.3.0, < 2.8.0)
-      json
     coderay (1.1.1)
     concurrent-ruby (1.1.3)
     crack (0.4.3)
@@ -240,7 +237,6 @@ DEPENDENCIES
   awesome_print
   bourbon (~> 4.2.0)
   bundler-audit
-  capybara-webkit
   database_cleaner
   dotenv-rails
   factory_girl_rails
@@ -276,4 +272,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.17.2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,9 +13,6 @@ module Features
 end
 
 RSpec.configure do |config|
-  config.before(:each, js: true) do
-    page.driver.block_unknown_urls
-  end
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
@@ -23,4 +20,3 @@ RSpec.configure do |config|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :webkit


### PR DESCRIPTION
It no longer installs on macOS Sierra (the [wiki] recommends checking out an old version of Homebrew to install Qt5.5), making it difficult to run tests on a new computer.

In addition, we don't have any Javascript tests.

Thus, the easiest thing is just to not use capybara-webkit.

[wiki]: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit
