### PR TITLE
Regenerate new-style binstubs for Rails

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
-APP_PATH = File.expand_path('../../config/application', __FILE__)
+APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,8 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run


### PR DESCRIPTION
Running any rails command (like `rails server`) showed this warning:

```
Array values in the parameter to `Gem.paths=` are deprecated.
Please use a String or nil.
An Array ({"GEM_PATH"=>["/Users/gabe/.asdf/installs/ruby/2.4.2/lib/ruby/gems/2.4.0", "/Users/gabe/.gem/ruby/2.4.0"]}) was passed in from bin/rails:3:in `load'
```

To fix the warning, I ran this command:

```
rails app:update:bin
```

@edwardloveall