### PR TITLE
Update Puma for heroku-18 stack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (3.6.0)
+    puma (3.12.0)
     rack (2.0.6)
     rack-canonical-host (0.2.2)
       addressable (> 0, < 3)


### PR DESCRIPTION
Our apps are on the deprecated `cedar-14` stack.

In order to upgrade to the new `heroku-18` stack, we need to upgrade Puma, since version 3.6.0 fails to build on `heroku-18`.

(I confirmed that this works on `heroku-18` by deploying to staging.)

More about Heroku stacks here: https://devcenter.heroku.com/articles/stack