### PR TITLE
Correctly show failing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ jobs:
     working_directory: ~/gabebw/hotline-webring
     parallelism: 1
     shell: /bin/bash --login
-    environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
     - image: circleci/ruby:2.5.3-node
       environment:
@@ -22,8 +19,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Create Cache Directories
-          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+          name: Create Directories
+          command: mkdir -p test-results
       - run:
           name: Create .env
           command: cp .sample.env .env
@@ -52,16 +49,10 @@ jobs:
       - run: bundle exec bin/drake db:test:prepare
       - run:
           name: Run tests
-          command: bundle exec rspec -r rspec_junit_formatter --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+          command: bundle exec rspec -r rspec_junit_formatter --format RspecJunitFormatter -o test-results/rspec/results.xml
       - run:
           name: Check for Insecure Gems
           command: bundle exec bin/drake bundler:audit
 
       - store_test_results:
-          path: $CIRCLE_TEST_REPORTS
-
-      - store_artifacts:
-          path: $CIRCLE_ARTIFACTS
-
-      - store_artifacts:
-          path: $CIRCLE_TEST_REPORTS
+          path: test-results


### PR DESCRIPTION
You can see that the first commit, which removed `db:test:prepare` (which we do need), has a bad Circle CI output and doesn't summarize the failing tests at the top: https://circleci.com/gh/gabebw/hotline-webring/280

However, the latest commit, which stores test results correctly, does summarize the failing tests: https://circleci.com/gh/gabebw/hotline-webring/283

(I will remove the failing commit once this PR is approved.)

Using `path: $CIRCLE_TEST_REPORTS` made it look at a directory literally called `$CIRCLE_TEST_REPORTS`. It didn't use the value of the environment variable. Therefore, I now hardcode it as a string.

According to  https://circleci.com/docs/2.0/configuration-reference/#store_test_results, we should store it to `test-results/rspec/results.xml`, and save `test-results`, so now we do that instead of using environment variables.

I'm not sure we have any artifacts, so I removed that entirely.

@edwardloveall