### PR TITLE
FactoryGirl is now named FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development, :test do
   gem "awesome_print"
   gem "bundler-audit", require: false
   gem "dotenv-rails"
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.5.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,10 +71,10 @@ GEM
       railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     execjs (2.7.0)
-    factory_girl (4.7.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.7.0)
-      factory_girl (~> 4.7.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     ffi (1.9.25)
     flutie (2.1.0)
@@ -246,7 +246,7 @@ DEPENDENCIES
   bourbon (~> 4.2.0)
   bundler-audit
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   flutie
   formulaic
   high_voltage

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,10 +1,10 @@
 if Rails.env.development? || Rails.env.test?
-  require "factory_girl"
+  require "factory_bot"
 
   namespace :dev do
     desc "Sample data for local development environment"
     task prime: "db:setup" do
-      include FactoryGirl::Syntax::Methods
+      include FactoryBot::Syntax::Methods
 
       create(:redirection, slug: "adarsh", url: "http://adarsh.io")
       create(:redirection, slug: "thorncp", url: "http://thorn.co")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :redirection do
     sequence(:slug) { |n| "slug#{n}" }
     sequence(:url) { |n| "http://example#{n}.com" }
-    next_id -1
+    next_id { -1 }
 
     after(:create) do |redirection|
       if redirection.next_id == -1

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
It was renamed in version 4.8.2: https://github.com/thoughtbot/factory_bot/blob/master/NEWS

This also fixes a small warning from the new FactoryBot version:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot
5.0. Please use dynamic attributes instead by wrapping the attribute
value in a block:

  next_id { -1 }
```