### PR TITLE
Use a CircleCI cache across different branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       # Restore the dependency cache
       - restore_cache:
           keys:
-          - hotlinewebring-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          - hotlinewebring-gemfile-{{ checksum "Gemfile.lock" }}
 
       - run:
           name: Bundle Install
@@ -36,7 +36,7 @@ jobs:
 
       # Save dependency cache
       - save_cache:
-          key: hotlinewebring-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: hotlinewebring-gemfile-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
             - ~/.bundle


### PR DESCRIPTION
Previously, builds would start a new cache in these cases:

* when building a new branch for the first time (since the branch name changed)
* when `Gemfile.lock` changes

However, the cache only saves Gemfile-related paths. Therefore, the cache is OK to use for new branches, as long as the `Gemfile.lock` is the same.

After this commit, a build can use a different branch's cache as long as they're using the same `Gemfile.lock`. This should significantly speed up the first build on new branches.

I've also changed the name of the cache to include `gemfile`, so that if we add other caches in the future, it doesn't get confusing.