### PR TITLE
Bring back Capybara gem so feature specs run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
 end
 
 group :test do
+  gem "capybara"
   gem "launchy"
   gem "rspec_junit_formatter"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,13 @@ GEM
     bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.4)
     crack (0.4.3)
@@ -93,6 +100,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -221,6 +231,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -230,6 +242,7 @@ DEPENDENCIES
   awesome_print
   bourbon (~> 4.2.0)
   bundler-audit
+  capybara
   dotenv-rails
   factory_bot_rails
   flutie


### PR DESCRIPTION
In PR #105, we removed Capybara because it's not in our Gemfile explicitly and #105 removed the last gem depending on Capybara.

Because of this, none of our feature specs run:

```
1) User visits homepage sees list of redirections
  # Feature specs require the Capybara
  #  (http://github.com/jnicklas/capybara) gem, version 2.2.0 or later.
  #  We recommend version 2.4.0 or later to avoid some deprecation
  #  warnings and have support for `config.expose_dsl_globally =
  #  false`.
  # ./spec/features/user_visits_homepage_spec.rb:4
```

Therefore, bring back Capybara to run feature specs.