### PR TITLE
Prefer `heroku local` to Foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,15 @@ Set up the repo:
 
     $ ./bin/setup
 
-Run it with Foreman:
+Run the app using [Heroku Local]:
 
-    $ foreman start
+    $ heroku local
+
+[Heroku Local]: https://devcenter.heroku.com/articles/heroku-local
 
 Run the specs:
 
     $ bin/drake spec
-
-If you don't have `foreman`, see [Foreman's install instructions][foreman]. It
-is [purposefully excluded from the project's `Gemfile`][exclude].
-
-[foreman]: https://github.com/ddollar/foreman
-[exclude]: https://github.com/ddollar/foreman/pull/437#issuecomment-41110407
 
 ## Removing a site from the webring
 

--- a/bin/setup
+++ b/bin/setup
@@ -23,13 +23,10 @@ if [ -z "$CI" ]; then
   # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
   mkdir -p .git/safe
 
-  # Pick a port for Foreman
-  if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
-    printf 'port: 3000\n' >> .foreman
-  fi
-
-  if ! command -v foreman > /dev/null; then
-    gem install foreman
+  if ! command -v heroku > /dev/null; then
+    echo "!! Please install the Heroku CLI: "
+    echo "!!  https://devcenter.heroku.com/articles/heroku-cli#download-and-install"
+    exit 1
   fi
 
   heroku git:remote --remote staging --app hotline-webring-staging || true


### PR DESCRIPTION
`heroku local` has been the preferred solution for a while now.

The `bin/setup` script now requires you to install `heroku`.