### PR TITLE
Store the whole original referring URL

### DIFF
--- a/app/services/redirection_creation.rb
+++ b/app/services/redirection_creation.rb
@@ -12,6 +12,7 @@ class RedirectionCreation
     redirection = Redirection.new(slug: slug)
 
     if referrer.present?
+      redirection.original_url = referrer
       redirection.url = referrer_hostname
       Ring.new(redirection).link
       redirection

--- a/db/migrate/20181220204317_add_original_url_to_redirection.rb
+++ b/db/migrate/20181220204317_add_original_url_to_redirection.rb
@@ -1,0 +1,11 @@
+class AddOriginalUrlToRedirection < ActiveRecord::Migration[5.2]
+  def up
+    add_column :redirections, :original_url, :text
+    update 'UPDATE redirections SET original_url = url'
+    change_column_null :redirections, :original_url, false
+  end
+
+  def down
+    remove_column :redirections, :original_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2015_12_17_165101) do
+ActiveRecord::Schema.define(version: 2018_12_20_204317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2015_12_17_165101) do
     t.integer "next_id", null: false
     t.string "slug", null: false
     t.text "url", null: false
+    t.text "original_url", null: false
     t.index ["next_id"], name: "index_redirections_on_next_id", unique: true
     t.index ["slug"], name: "index_redirections_on_slug", unique: true
     t.index ["url"], name: "index_redirections_on_url", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,12 +2,14 @@ unless Redirection.exists?(slug: "gabe")
   gabe = Redirection.create!(
     slug: "gabe",
     url: "http://gabebw.com",
+    original_url: "https://gabebw.com",
     next_id: -1, # fake data
   )
 
   edward = Redirection.new(
     slug: "edward",
     url: "http://edwardloveall.com",
+    original_url: "https://edwardloveall.com"
   )
 
   edward.update!(next: gabe)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:slug) { |n| "slug#{n}" }
     sequence(:url) { |n| "http://example#{n}.com" }
     next_id { -1 }
+    original_url { url }
 
     after(:create) do |redirection|
       if redirection.next_id == -1

--- a/spec/services/redirection_creation_spec.rb
+++ b/spec/services/redirection_creation_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RedirectionCreation do
       expect(redirection.url).to eq referrer_hostname
     end
 
+    it "stores the original unchanged referrer" do
+      referrer_hostname = "https://cool.example.com"
+      full_referrer = "#{referrer_hostname}/something/else"
+      slug = "cool-slug"
+
+      RedirectionCreation.perform(full_referrer, slug)
+
+      redirection = Redirection.find_by!(slug: slug)
+      expect(redirection.original_url).to eq full_referrer
+    end
+
     it "links the new redirection into the ring" do
       first_redirection = Redirection.first
       old_next = first_redirection.next


### PR DESCRIPTION
We currently store only the hostname of the HTTP referrer (e.g. `gabebw.com/posts/2018/whatever` is saved as just `gabebw.com`).

This is a problem for pages on free sites, where the homepage for a given user is not the root hostname but a subdirectory (e.g. `freepages.rootsweb.com/~gabebw`).

This is not a fix for issue #58, but it does allow us to manually fix that issue if it recurs.