### PR TITLE
Configure rack-timeout with env variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,4 +18,3 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
   config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
 end
-Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i


### PR DESCRIPTION
The `Rack::Timeout.timeout=` method no longer exists. It was removed in rack-timeout 0.5, which we upgraded to in commit 003248f9.

Relevant Suspenders PR: https://github.com/thoughtbot/suspenders/pull/920