### PR TITLE
Make the site look a bit better on mobile

### DIFF
--- a/app/assets/stylesheets/_mobile.scss
+++ b/app/assets/stylesheets/_mobile.scss
@@ -1,6 +1,7 @@
 @include media($large-screen-down) {
   h2 {
     font-size: 3.5em;
+    margin-top: 1rem;
   }
 
   .homes-show {
@@ -22,6 +23,10 @@
 
     iframe {
       display: none;
+    }
+
+    td.url {
+      word-wrap: break-word;
     }
   }
 }

--- a/app/views/redirections/_redirection.html.erb
+++ b/app/views/redirections/_redirection.html.erb
@@ -1,4 +1,4 @@
 <tr>
   <td><%= redirection.slug %></td>
-  <td><%= link_to(redirection.url, redirection.url) %></td>
+  <td class="url"><%= link_to(redirection.url, redirection.url) %></td>
 </tr>


### PR DESCRIPTION
* Word-wrap the URLs so they don't extend off the side of the screen
* Add a bit more padding at the top of the site on smaller screens

## Before (iPhone 8+)

Note the lack of top padding and the way the URLs extend off the side of the screen.

<img width="336" alt="Hotline Webring 2019-05-26 20-15-10" src="https://user-images.githubusercontent.com/257678/58393298-02aa3380-7ff3-11e9-9202-f69e52133dd5.png">
<img width="362" alt="Hotline Webring 2019-05-26 20-15-51" src="https://user-images.githubusercontent.com/257678/58393311-1190e600-7ff3-11e9-9c75-27727ad8a15a.png">

## After

There's now more padding at the top, and the URLs wrap inside the table.

<img width="389" alt="Hotline Webring 2019-05-26 20-16-31" src="https://user-images.githubusercontent.com/257678/58393336-28cfd380-7ff3-11e9-948a-79d14192c7f2.png">

<img width="386" alt="Hotline Webring 2019-05-26 20-17-32" src="https://user-images.githubusercontent.com/257678/58393377-4dc44680-7ff3-11e9-9b14-f94c1198ed03.png">
