### PR TITLE
Rescue errors and detect redirects in link audit

### DIFF
--- a/lib/tasks/link-audit.rake
+++ b/lib/tasks/link-audit.rake
@@ -15,7 +15,7 @@ task link_audit: :environment do
       case response
       when Net::HTTPSuccess then
         response.body
-      when Net::HTTPRedirection then
+      when Net::HTTPRedirection, Net::HTTPMovedPermanently then
         fetch(response["location"])
       end
     rescue SocketError


### PR DESCRIPTION
When trying to run `Net::HTTP.get_response` on a website that is not online (like http://alexfox.me, in our webring), it throws a `SocketError`.

Now we rescue that error and print an error message, rather than crashing the audit.

I also improved the redirection detection to now support `Net::HTTPMovedPermanently` (a 301 Redirect) as well.