### PR TITLE
Allow encoded slashes

### DIFF
--- a/lib/tasks/link-audit.rake
+++ b/lib/tasks/link-audit.rake
@@ -27,12 +27,17 @@ task link_audit: :environment do
     html = fetch(redirection.url)
 
     if html
-      next_link = "hotlinewebring.club/#{redirection.slug}/next"
-      prev_link = "hotlinewebring.club/#{redirection.slug}/previous"
+      # Surprisingly, this works just fine:
+      # <a href="https:&#x2F;&#x2F;hotlinewebring.club&#x2F;alexey&#x2F;next">next</a>
+      # Therefore, we should allow encoded slashes.
+      slash = Regexp.union(['/', '&#x2f;'])
+      host = 'hotlinewebring.club'
+      next_link = /#{host}#{slash}#{redirection.slug}#{slash}next/
+      prev_link = /#{host}#{slash}#{redirection.slug}#{slash}previous/
 
       missing_links = []
-      missing_links << "next" if !html.include?(next_link)
-      missing_links << "prev" if !html.include?(prev_link)
+      missing_links << "next" if !html.match?(next_link)
+      missing_links << "prev" if !html.match?(prev_link)
 
       if missing_links.empty?
         green("#{redirection.url} is all good")


### PR DESCRIPTION
As you can see by doing `curl https://alexeyzabelin.com`, this HTML works just fine in the browser:

```
<a href="https:&#x2F;&#x2F;hotlinewebring.club&#x2F;alexey&#x2F;next">next</a>
```

`&#x2F` is the hexadecimal encoding of `/`.

Therefore, it should "count" as a real HLWR link.

I have updated the link checker to allow both versions of the forward slash, regular and encoded.