### PR TITLE
Make the website unfurl in Slack and Twitter

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,10 @@
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
+  <meta property="og:title" content="Hotline Webring" />
+  <meta property="og:description" content="A friendly ring of cool websites. Join today!" />
+  <meta name="twitter:card" value="summary" />
+  <meta name="twitter:website" value="@hotlinewebring" />
   <%#
     Configure default and controller-, and view-specific titles in
     config/locales/en.yml. For more see:


### PR DESCRIPTION
An "unfurl" is what Slack calls its link previews: https://api.slack.com/docs/message-link-unfurling#classic_unfurling

Fixes #176

Here's what it looks like in [Twitter's card validator](https://cards-dev.twitter.com/validator):

<img width="560" alt="Card Validator | Twitter Developers 2019-06-13 19-20-19" src="https://user-images.githubusercontent.com/257678/59479031-52b93080-8e10-11e9-9445-93b37905ee99.png">

And in Slack:

<img width="605" alt="Slack - Pillow Fort 2019-06-13 19-22-44" src="https://user-images.githubusercontent.com/257678/59479112-a6c41500-8e10-11e9-9350-ecb26636b524.png">

