### PR TITLE
Remove unneeded rails_stdout_logging gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,4 @@ end
 
 group :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_stdout_logging (0.0.5)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -269,7 +268,6 @@ DEPENDENCIES
   rack-canonical-host
   rack-timeout
   rails (~> 6.0.2)
-  rails_stdout_logging
   rspec-rails (~> 3.5)
   rspec_junit_formatter
   sassc-rails


### PR DESCRIPTION
When deploying the Rails 6 app to Heroku, I saw this warning:

>DEPRECATION WARNING: Including LoggerSilence is deprecated and will be removed in Rails 6.1. Please use `ActiveSupport::LoggerSilence` instead

The warning is apparently coming from the rails_stdout_logging gem, according to this issue: https://github.com/heroku/rails_12factor/issues/33.

Based on the README (https://github.com/heroku/rails_12factor#migrating-to-rails-5), we already do everything that rails_stdout_logging would do for us, manually (see `config/enviroments/production.rb` for our `RAILS_SERVE_STATIC_FILES`- and `RAILS_LOG_TO_STDOUT`-related settings).

Thus, we can just remove the gem.

https://github.com/gabebw/hotline-webring/blob/96056887cff05a8ccecfd99c4865da22eccf1e6c/config/environments/production.rb#L6

https://github.com/gabebw/hotline-webring/blob/96056887cff05a8ccecfd99c4865da22eccf1e6c/config/environments/production.rb#L23-L27