### PR TITLE
Allow blacklisting certain URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Use `Redirection#unlink`:
 This will destroy the `Redirection` and re-link its ring neighbors, sealing the
 breach.
 
+## Blacklisting
+
+When blacklisting a URL, specify the bare URL, without `http` or `www`
+subdomain.
+
+To blacklist everything from `evil.com` but none of its subdomains:
+
+    BlacklistedReferrer.create!(host_with_path: "evil.com")
+
+To blacklist everything under the `/one/` directory (`evil.com/one/*`), but not
+the root (for example, to blacklist a user directory):
+
+    BlacklistedReferrer.create!(host_with_path: "good.com/~evil")
+
+To blacklist a subdomain:
+
+    BlacklistedReferrer.create!(host_with_path: "evil.good.com")
+
 ## Guidelines
 
 Use the following guides for getting things done, programming well, and

--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -1,5 +1,6 @@
 class RedirectionsController < ApplicationController
   before_action :ensure_referrer_is_not_localhost
+  before_action :ensure_referrer_is_not_blacklisted
 
   def next
     redirection = find_or_create_redirection
@@ -28,6 +29,12 @@ class RedirectionsController < ApplicationController
   def ensure_referrer_is_not_localhost
     if HostValidator.new(referrer).invalid?
       redirect_to page_path("localhost")
+    end
+  end
+
+  def ensure_referrer_is_not_blacklisted
+    if Blacklist.new(referrer).blacklisted?
+      redirect_to Redirection.first.url
     end
   end
 end

--- a/app/models/blacklist.rb
+++ b/app/models/blacklist.rb
@@ -1,0 +1,21 @@
+class Blacklist
+  def initialize(possible_match)
+    @possible_match = possible_match
+  end
+
+  def blacklisted?
+    if possible_match.nil?
+      false
+    else
+      host = URI.parse(possible_match).host
+
+      BlacklistedReferrer.where("host_with_path LIKE ?", "#{host}%").
+        or(BlacklistedReferrer.where("'www.'||host_with_path LIKE ?", "#{host}%")).
+        any?
+    end
+  end
+
+  private
+
+  attr_reader :possible_match
+end

--- a/app/models/blacklisted_referrer.rb
+++ b/app/models/blacklisted_referrer.rb
@@ -1,0 +1,2 @@
+class BlacklistedReferrer < ActiveRecord::Base
+end

--- a/db/migrate/20200312175018_create_blacklisted_referrers.rb
+++ b/db/migrate/20200312175018_create_blacklisted_referrers.rb
@@ -1,0 +1,10 @@
+class CreateBlacklistedReferrers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :blacklisted_referrers do |t|
+      t.string :host_with_path, null: false
+      t.index :host_with_path, unique: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,18 +2,25 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_20_204317) do
+ActiveRecord::Schema.define(version: 2020_03_12_175018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "blacklisted_referrers", force: :cascade do |t|
+    t.string "host_with_path", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["host_with_path"], name: "index_blacklisted_referrers_on_host_with_path", unique: true
+  end
 
   create_table "redirections", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe RedirectionsController do
           end
         end
       end
+
+      context "when the URL is blacklisted" do
+        it "does not create a redirection and redirects to the first redirection" do
+          create(:blacklisted_referrer, host_with_path: "evil.com")
+          slug = "i-am-evil"
+          url = "http://evil.com/something"
+          request.env["HTTP_REFERER"] = url
+
+          get action, params: { slug: slug }
+
+          expect(Redirection.where(slug: slug)).to be_empty
+          expect(response).to redirect_to Redirection.first.url
+        end
+      end
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
+  factory :blacklisted_referrer do
+    sequence(:host_with_path) { |n| "evil.com/#{n}" }
+  end
+
   factory :redirection do
     sequence(:slug) { |n| "slug#{n}" }
     sequence(:url) { |n| "http://example#{n}.com" }

--- a/spec/models/blacklist_spec.rb
+++ b/spec/models/blacklist_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Blacklist do
+  describe '#blacklisted?' do
+    context 'blocking evil.com' do
+      before do
+        create(:blacklisted_referrer, host_with_path: "evil.com")
+      end
+
+      it "matches regardless of HTTP vs HTTPS" do
+        url = "http://www.evil.com"
+        expect(Blacklist.new(url)).to be_blacklisted
+      end
+
+      it "matches regardless of www. prefix" do
+        url = "https://evil.com"
+        expect(Blacklist.new(url)).to be_blacklisted
+      end
+
+      it "matches the URL exactly" do
+        url = "https://www.evil.com"
+        expect(Blacklist.new(url)).to be_blacklisted
+      end
+
+      it "matches any path under the URL" do
+        url = "https://www.evil.com/anything/goes/here"
+        expect(Blacklist.new(url)).to be_blacklisted
+      end
+
+      it "does not match a subdomain that isn't 'www'" do
+        url = "https://good.evil.com"
+        expect(Blacklist.new(url)).not_to be_blacklisted
+      end
+
+      it "does not match a subdomain that isn't 'www' with a path" do
+        url = "https://good.evil.com/anything/goes/here"
+        expect(Blacklist.new(url)).not_to be_blacklisted
+      end
+
+      it "does not match a different domain" do
+        url = "https://good.com/"
+        expect(Blacklist.new(url)).not_to be_blacklisted
+      end
+
+      it "never matches nil" do
+        expect(Blacklist.new(nil)).not_to be_blacklisted
+      end
+    end
+  end
+end


### PR DESCRIPTION
The expected process for blacklisting:

* We manually add the host as a BlacklistedReferrer
* We manually unlink the offending Redirection

After that, whenever someone clicks "next" or "previous" from the offending site, they will be taken to the first Redirection and the site will _not_ be added to the ring.

Mostly fixes #206. Later, we'll probably want a specific page saying "you can't join" as detailed in #206. This PR just silently won't let them join.